### PR TITLE
test(frontend): fix Jest alias resolution for @/* and related paths

### DIFF
--- a/jest/jest.config.frontend.cjs
+++ b/jest/jest.config.frontend.cjs
@@ -27,6 +27,17 @@ module.exports = {
     '<rootDir>/src/__tests__/setup.ts'
   ],
   testEnvironmentOptions: { url: 'http://localhost:3000' },
+
+  // Frontend path aliases (explicit to avoid tsconfig loader edge cases)
+  moduleNameMapper: {
+    ...(base.moduleNameMapper || {}),
+    '^@/(.*)$': '<rootDir>/apps/frontend/src/$1',
+    '^@components/(.*)$': '<rootDir>/apps/frontend/src/components/$1',
+    '^@hooks/(.*)$': '<rootDir>/apps/frontend/src/hooks/$1',
+    '^@lib/(.*)$': '<rootDir>/apps/frontend/src/lib/$1',
+    '^@contexts/(.*)$': '<rootDir>/apps/frontend/src/contexts/$1'
+  },
+
   // Increase timeout for CI environment
   testTimeout: 15000
 };


### PR DESCRIPTION
Adds explicit moduleNameMapper for @/, @components/, @hooks/, @lib/, @contexts/* in jest/
  jest.config.frontend.cjs to align with centralized tsconfig paths. Unblocks failing frontend tests observed in CI.

 Also note: prior commit 0171e41 removes @swc/* and adds gcompat to Alpine Dockerfile to mitigate SWC segfaults.



