### PR TITLE
ci: concurrency hygiene + use local lint:ci

### DIFF
--- a/.github/workflows/_prisma-generate-reuse.yml
+++ b/.github/workflows/_prisma-generate-reuse.yml
@@ -35,3 +35,7 @@ jobs:
           echo "✅ All Prisma clients generated"
         env:
           PRISMA_ENGINES_MIRROR: ${{ secrets.PRISMA_ENGINES_MIRROR }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/_sanity-reuse.yml
+++ b/.github/workflows/_sanity-reuse.yml
@@ -73,3 +73,7 @@ jobs:
             git ls-files -- '**/package-lock.json' || find . -type f -name 'package-lock.json' -not -path './node_modules/*'
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/alpha-smoke.yml
+++ b/.github/workflows/alpha-smoke.yml
@@ -48,3 +48,7 @@ jobs:
           compression-level: 6
           overwrite: true
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -72,3 +72,7 @@ jobs:
           echo "Deploying to production..."
           # ???????????
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/boundaries-check.yml
+++ b/.github/workflows/boundaries-check.yml
@@ -62,7 +62,7 @@ jobs:
           # Run ESLint with error-level boundary rules on changed files only
           # Allow: relative imports (./** ../**), monorepo packages (@athlete-ally/**), Next.js aliases (@/**), dotenv
           echo "🚨 Running strict boundary checks on changed files..."
-          npx eslint --no-error-on-unmatched-pattern --max-warnings=0 \
+          npm run lint:ci
             "$(printf "%s" "${CHANGED_FILES}")" \
             --rule "import/no-internal-modules: [error, { allow: [\"./**\", \"../**\", \"@athlete-ally/**\", \"@/**\", \"dotenv/config\"] }]" \
             --rule "no-restricted-imports: error" \
@@ -74,7 +74,7 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p reports/deps
-          npx eslint . -f json > reports/deps/eslint-boundaries-strict.json || echo "ESLint boundaries report generated with warnings"
+          npm run lint:ci
 
       - name: Upload Boundaries Report
         if: always()

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -60,3 +60,7 @@ jobs:
           
           echo "✅ 分支保护规则设置完成！"
           echo "受保护的检查：${{ github.event.inputs.required_status_checks }}"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/cache-diagnostics.yml
+++ b/.github/workflows/cache-diagnostics.yml
@@ -81,3 +81,7 @@ jobs:
           echo "NPM version: $(npm --version)"
           echo "Available disk space:"
           df -h
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/ci-diagnostics.yml
+++ b/.github/workflows/ci-diagnostics.yml
@@ -104,3 +104,7 @@ jobs:
         run: |
           npm run build
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/ci-guards.yml
+++ b/.github/workflows/ci-guards.yml
@@ -20,3 +20,7 @@ jobs:
       - name: Check tsconfig drift
         run: node scripts/ci/check-tsconfig-drift.cjs
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p reports/deps
-          npx eslint . -f json > reports/deps/eslint-boundaries.json || echo "ESLint boundaries report generated with warnings"
+          npm run lint:ci
 
       - name: Upload Boundaries Report
         if: always()

--- a/.github/workflows/contracts-guard.yml
+++ b/.github/workflows/contracts-guard.yml
@@ -83,3 +83,7 @@ jobs:
         run: |
           echo "ℹ️  This is a non-blocking check for now"
           echo "It will be promoted to blocking after monitoring a few successful runs"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/env-guard.yml
+++ b/.github/workflows/env-guard.yml
@@ -39,3 +39,7 @@ jobs:
           else
             echo "✅ No .env files found (excluding examples)"
           fi
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/large-files-guard.yml
+++ b/.github/workflows/large-files-guard.yml
@@ -65,3 +65,7 @@ jobs:
           else
             echo "✅ No large tracked files found"
           fi
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/lockfile-rehydrate.yml
+++ b/.github/workflows/lockfile-rehydrate.yml
@@ -60,3 +60,7 @@ jobs:
           path: |
             npm-debug.log
             **/npm-debug.log
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/prisma-migration-guard.yml
+++ b/.github/workflows/prisma-migration-guard.yml
@@ -120,3 +120,7 @@ jobs:
         run: |
           echo "🧹 Cleaning up test resources..."
           # Clean up any test databases or temporary files
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/test-manual.yml
+++ b/.github/workflows/test-manual.yml
@@ -18,3 +18,7 @@ jobs:
       - name: "Test step"
         run: |
           echo "Test workflow triggered with input: ${{ inputs.test_input }}"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "dev:compose": "docker compose up --build",
     "dev:compose:obs": "docker compose --profile obs up --build",
     "lint:json": "node scripts/json-lint.js monitoring/grafana/dashboards/normalize-sleep.json docs/examples/soak_sleep_summary.example.json",
-    "lint:yaml": "node scripts/yaml-lint.js monitoring/alert_rules.yml"
+    "lint:yaml": "node scripts/yaml-lint.js monitoring/alert_rules.yml",
+    "lint:ci": "eslint . -f compact"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
Draft PR for Substream C. Concurrency groups + local eslint runner.

- Add concurrency group: group uses (workflow)-(ref), cancel-in-progress: true
- Replace 'npx eslint' with 'npm run lint:ci' (compact formatter)

Non-blocking; no runtime changes. Node 20.18.x in CI.