### PR TITLE
hotfix: Copy scripts directory in all service Dockerfiles

### DIFF
--- a/services/analytics/Dockerfile
+++ b/services/analytics/Dockerfile
@@ -9,6 +9,8 @@ COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages
 COPY services/analytics ./services/analytics
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # 運行完整的 monorepo 安裝
 RUN npm ci

--- a/services/exercises/Dockerfile
+++ b/services/exercises/Dockerfile
@@ -9,6 +9,8 @@ COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages
 COPY services/exercises ./services/exercises
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # 運行完整的 monorepo 安裝
 RUN npm ci

--- a/services/fatigue/Dockerfile
+++ b/services/fatigue/Dockerfile
@@ -9,6 +9,8 @@ COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages
 COPY services/fatigue ./services/fatigue
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # 運行完整的 monorepo 安裝
 RUN npm ci

--- a/services/ingest-service/Dockerfile
+++ b/services/ingest-service/Dockerfile
@@ -8,6 +8,8 @@ COPY tsconfig.base.json ./
 COPY turbo.json ./
 COPY packages ./packages
 COPY services/ingest-service ./services/ingest-service
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # Install and build
 RUN npm ci

--- a/services/insights-engine/Dockerfile
+++ b/services/insights-engine/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /usr/src/app
 # Copy package files
 COPY package*.json ./
 COPY services/insights-engine/package.json ./services/insights-engine/
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 COPY packages/event-bus/package.json ./packages/event-bus/
 COPY packages/shared-types/package.json ./packages/shared-types/
 COPY packages/contracts/package.json ./packages/contracts/
@@ -22,6 +24,8 @@ WORKDIR /usr/src/app
 # Copy package files
 COPY package*.json ./
 COPY services/insights-engine/package.json ./services/insights-engine/
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 COPY packages/event-bus/package.json ./packages/event-bus/
 COPY packages/shared-types/package.json ./packages/shared-types/
 COPY packages/contracts/package.json ./packages/contracts/
@@ -31,6 +35,8 @@ RUN npm ci
 
 # Copy source code
 COPY services/insights-engine ./services/insights-engine
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 COPY packages ./packages
 COPY tsconfig.base.json ./
 

--- a/services/normalize-service/Dockerfile
+++ b/services/normalize-service/Dockerfile
@@ -8,6 +8,8 @@ COPY tsconfig.base.json ./
 COPY turbo.json ./
 COPY packages ./packages
 COPY services/normalize-service ./services/normalize-service
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # Install and generate Prisma client
 RUN npm ci

--- a/services/planning-engine/Dockerfile
+++ b/services/planning-engine/Dockerfile
@@ -9,6 +9,8 @@ COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages
 COPY services/planning-engine ./services/planning-engine
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # 運行完整的 monorepo 安裝
 RUN npm ci

--- a/services/profile-onboarding/Dockerfile
+++ b/services/profile-onboarding/Dockerfile
@@ -9,6 +9,8 @@ COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages
 COPY services/profile-onboarding ./services/profile-onboarding
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # 運行完整的 monorepo 安裝
 RUN npm ci

--- a/services/workouts/Dockerfile
+++ b/services/workouts/Dockerfile
@@ -9,6 +9,8 @@ COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages
 COPY services/workouts ./services/workouts
+# 拷貝 scripts 目錄（preinstall 鉤子需要）
+COPY scripts ./scripts
 
 # 運行完整的 monorepo 安裝
 RUN npm ci


### PR DESCRIPTION
## Emergency Hotfix

Fixes Docker build failures introduced by the preinstall hook in package.json.

## Root Cause

The root `package.json` has a preinstall hook that runs:
```json
"preinstall": "node scripts/check-node-version.cjs"
```

However, service Dockerfiles were not copying the `scripts/` directory before running `npm ci`, causing the preinstall hook to fail with:
```
Error: Cannot find module '/app/scripts/check-node-version.cjs'
```

## Fix

Added `COPY scripts ./scripts` before `RUN npm ci` in all service Dockerfiles.

## Services Fixed

- ✅ analytics
- ✅ exercises  
- ✅ fatigue
- ✅ ingest-service
- ✅ insights-engine (3 build stages)
- ✅ normalize-service
- ✅ planning-engine
- ✅ profile-onboarding
- ✅ workouts

## Testing

Verified the fix resolves the planning-engine Docker build error reported in the failed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)