### PR TITLE
hotfix: Copy config directory in Dockerfiles (missing from PR #70)

### DIFF
--- a/services/analytics/Dockerfile
+++ b/services/analytics/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 關鍵：從根上下文，拷貝所有構建所需的文件
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages

--- a/services/exercises/Dockerfile
+++ b/services/exercises/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 關鍵：從根上下文，拷貝所有構建所需的文件
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages

--- a/services/fatigue/Dockerfile
+++ b/services/fatigue/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 關鍵：從根上下文，拷貝所有構建所需的文件
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages

--- a/services/ingest-service/Dockerfile
+++ b/services/ingest-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Copy monorepo build context from root
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 COPY packages ./packages
 COPY services/ingest-service ./services/ingest-service

--- a/services/insights-engine/Dockerfile
+++ b/services/insights-engine/Dockerfile
@@ -39,6 +39,7 @@ COPY services/insights-engine ./services/insights-engine
 COPY scripts ./scripts
 COPY packages ./packages
 COPY tsconfig.base.json ./
+COPY config ./config
 
 # Generate Prisma client
 WORKDIR /usr/src/app/services/insights-engine

--- a/services/normalize-service/Dockerfile
+++ b/services/normalize-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Copy monorepo build context from root
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 COPY packages ./packages
 COPY services/normalize-service ./services/normalize-service

--- a/services/planning-engine/Dockerfile
+++ b/services/planning-engine/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 關鍵：從根上下文，拷貝所有構建所需的文件
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages

--- a/services/profile-onboarding/Dockerfile
+++ b/services/profile-onboarding/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 關鍵：從根上下文，拷貝所有構建所需的文件
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages

--- a/services/workouts/Dockerfile
+++ b/services/workouts/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 關鍵：從根上下文，拷貝所有構建所需的文件
 COPY package*.json ./
 COPY tsconfig.base.json ./
+COPY config ./config
 COPY turbo.json ./
 # 拷貝所有需要被 link 的 workspace
 COPY packages ./packages


### PR DESCRIPTION
## Emergency Hotfix - Missing Config Directory

This is the **MISSING piece from PR #70** that was not included in the merge.

## Root Cause

PR #70 was merged with commit `c3aa1d6`, but it only included the first fix (turbo filter names) and **did not include the config directory copy fix**. This is causing all Docker builds to fail with:

```
@athlete-ally/logger:build: error TS5083: Cannot read file '/app/config/typescript/tsconfig.base.json'
```

## Why This Happens

1. Root `tsconfig.base.json` extends from `./config/typescript/tsconfig.base.json`
2. Packages like `@athlete-ally/logger` extend from `../../config/typescript/tsconfig.base.json`
3. Dockerfiles copy `tsconfig.base.json` but not the `config/` directory
4. TypeScript build fails because it can't find the extended config file

## Fix Applied

Added `COPY config ./config` immediately after `COPY tsconfig.base.json ./` in all service Dockerfiles:

```dockerfile
COPY tsconfig.base.json ./
COPY config ./config        ← THIS LINE WAS MISSING
COPY turbo.json ./
```

## Services Fixed

All 9 active service Dockerfiles:
- ✅ analytics
- ✅ exercises  
- ✅ fatigue
- ✅ ingest-service
- ✅ insights-engine
- ✅ normalize-service
- ✅ planning-engine
- ✅ profile-onboarding
- ✅ workouts

## Testing

This fix will resolve the TypeScript build failures in all service Docker builds.

## Why This Was Missed

PR #70 had two commits:
1. Fix turbo filter names ✅ (merged)
2. Copy config directory ❌ (NOT merged)

This PR contains only the missing config directory fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)