### PR TITLE
fix(test): resolve Jest setup file module resolution errors (#80)

### DIFF
--- a/jest/jest.config.frontend.cjs
+++ b/jest/jest.config.frontend.cjs
@@ -31,8 +31,7 @@ module.exports = {
     '.*useTrainingQueries\\.test\\.tsx$'
   ],
   setupFilesAfterEnv: [
-    '<rootDir>/apps/frontend/src/__tests__/setup.ts',
-    '<rootDir>/src/__tests__/setup.ts'
+    '<rootDir>/apps/frontend/src/__tests__/setup.ts'
   ],
   testEnvironmentOptions: { url: 'http://localhost:3000' },
 

--- a/jest/jest.config.services.cjs
+++ b/jest/jest.config.services.cjs
@@ -20,9 +20,7 @@ module.exports = {
   ],
   // No global test skipping - use describe.skip/it.skip in individual test files
   // See services/planning-engine/JEST_CONFIG.md for details
-  setupFilesAfterEnv: [
-    '<rootDir>/src/__tests__/setup.ts'
-  ],
+  // Each service has its own setup file at services/<service-name>/src/__tests__/setup.ts
   // CI并发控制 - 避免CI容器在高并发下不稳定
   maxWorkers: process.env.CI === 'true' ? 1 : '50%'
   // runInBand is handled by CI, not config


### PR DESCRIPTION
## Summary
Fixes Issue #80: Jest configuration error about missing setup.ts file

## Problem
Jest was looking for a non-existent setup file at `<rootDir>/src/__tests__/setup.ts`, causing contract tests and other tests to fail with:
```
Module <rootDir>/src/__tests__/setup.ts in the setupFilesAfterEnv option was not found
```

## Solution
- **Frontend config**: Removed invalid `<rootDir>/src/__tests__/setup.ts` path, kept only the correct path `<rootDir>/apps/frontend/src/__tests__/setup.ts`
- **Services config**: Removed global setup path since each service has its own setup file at `services/<service-name>/src/__tests__/setup.ts`

## Changes
- `jest/jest.config.frontend.cjs`: Fixed setupFilesAfterEnv path
- `jest/jest.config.services.cjs`: Removed invalid global setup path

## Testing
✅ Contract test now passes:
```bash
npx jest --config jest/jest.projects.cjs apps/frontend/src/__tests__/contracts/type-consistency.test.ts
```

## Priority
**P0 (Critical)** - This was blocking PR #90 and other test runs

---

Part of Phase 1 debt reduction work